### PR TITLE
handling `0000:00:00` and `0000:00:00 00:00:00` dates

### DIFF
--- a/lib/exiftool/field_parser.rb
+++ b/lib/exiftool/field_parser.rb
@@ -46,7 +46,7 @@ class Exiftool
     end
 
     def datish?
-      raw_value.is_a?(String) && display_key =~ /\bdate\b/i
+      raw_value.is_a?(String) && !(raw_value =~ /\A(\d{4}):((\d{2}):(0{2})|(0{2}):(\d{2}))\b/) && display_key =~ /\bdate\b/i
     end
 
     def for_date

--- a/test/exiftool_test.rb
+++ b/test/exiftool_test.rb
@@ -33,6 +33,11 @@ describe Exiftool do
         e[:source_file].must_equal Exiftool.expand_path(filename)
         validate_result(e, filename)
       end
+      Dir['test/*.tif'].each do |filename|
+        e = Exiftool.new(filename)
+        e[:source_file].must_equal Exiftool.expand_path(filename)
+        validate_result(e, filename)
+      end
     end
 
     it 'fails if there are multiple files provided and Exiftool is treated as a result' do

--- a/test/expected/Canon 20D.jpg.yaml
+++ b/test/expected/Canon 20D.jpg.yaml
@@ -47,7 +47,7 @@
 :metering_mode: Evaluative
 :focus_range: Not Known
 :canon_exposure_mode: Program AE
-:lens_type: Unknown (-1)
+:lens_type: n/a
 :focal_units: 1/mm
 :max_aperture: 5.6
 :min_aperture: 32
@@ -205,8 +205,10 @@
 :shutter_speed: !ruby/object:Rational
   denominator: 250
   numerator: 1
-:thumbnail_image: (Binary data 11259 bytes)
+:thumbnail_image: (Binary data 11259 bytes, use -b option to extract)
 :wb_rggb_levels: 1973 1015 1015 1663
 :blue_balance: 1.638424
 :light_value: 13.3
 :red_balance: 1.943842
+:megapixels: 8.2
+:file_type_extension: jpg

--- a/test/expected/Droid X.jpg.yaml
+++ b/test/expected/Droid X.jpg.yaml
@@ -76,5 +76,7 @@
 :shutter_speed: !ruby/object:Rational
   denominator: 15
   numerator: 1
-:thumbnail_image: (Binary data 32586 bytes)
+:thumbnail_image: (Binary data 32586 bytes, use -b option to extract)
 :light_value: 4.2
+:megapixels: 6.0
+:file_type_extension: jpg

--- a/test/expected/Epson_V700_Silverfast.tif.yaml
+++ b/test/expected/Epson_V700_Silverfast.tif.yaml
@@ -1,0 +1,42 @@
+---
+:file_name: Epson_V700_Silverfast.tif
+:file_size: 15 MB
+:file_modify_date: 2015-07-06 13:08:18 -0700
+:file_modify_date_civil: #<Date: 2015-07-06 ((2457210j,0s,0n),+0s,2299161j)>
+:file_access_date: 2015-07-07 10:21:02 -0700
+:file_access_date_civil: #<Date: 2015-07-07 ((2457211j,0s,0n),+0s,2299161j)>
+:file_inode_change_date: 2015-07-06 13:08:18 -0700
+:file_inode_change_date_civil: #<Date: 2015-07-06 ((2457210j,0s,0n),+0s,2299161j)>
+:file_permissions: rwx------
+:file_type: TIFF
+:file_type_extension: tif
+:mime_type: image/tiff
+:exif_byte_order: Big-endian (Motorola, MM)
+:image_width: 4683
+:image_height: 3066
+:bits_per_sample: 8
+:compression: Uncompressed
+:photometric_interpretation: BlackIsZero
+:make: EPSON
+:model: Perfection V700/V750
+:orientation: Horizontal (normal)
+:samples_per_pixel: 1
+:rows_per_strip: 1
+:x_resolution: 3200
+:y_resolution: 3200
+:planar_configuration: Chunky
+:resolution_unit: inches
+:software: SilverFast 8.5.0 r5 (May 22 2015)  bed2701 22.05.
+:xmp_toolkit: XMP Core 4.4.0-Exiv2
+:current_iptc_digest: 2154f0eb6905421bd65f27cc0115f5f7
+:date_created: "0000:00:00"
+:maker_note_unknown_binary: (Binary data 130 bytes, use -b option to extract)
+:exif_image_width: 4683
+:exif_image_height: 3066
+:subfile_type: Reduced-resolution image
+:strip_offsets: (Binary data 7238 bytes, use -b option to extract)
+:strip_byte_counts: (Binary data 4949 bytes, use -b option to extract)
+:image_size: 4683x3066
+:megapixels: 14.4
+:artist: Sergey Morozov
+:copyright: ©2015 Sergey Morozov - morozgrafix

--- a/test/expected/Epson_V700_Silverfast.tif.yaml
+++ b/test/expected/Epson_V700_Silverfast.tif.yaml
@@ -40,3 +40,4 @@
 :megapixels: 14.4
 :artist: Sergey Morozov
 :copyright: ©2015 Sergey Morozov - morozgrafix
+:create_date: "0000:00:00 00:00:00"

--- a/test/expected/IMG_2452.jpg.yaml
+++ b/test/expected/IMG_2452.jpg.yaml
@@ -54,7 +54,7 @@
 :focus_range: Auto
 :af_point: Face Detect
 :canon_exposure_mode: Easy
-:lens_type: Unknown (-1)
+:lens_type: n/a
 :focal_units: 1000/mm
 :max_aperture: 2.8
 :min_aperture: 8
@@ -100,7 +100,7 @@
 :rotation: 270
 :camera_temperature: 29 C
 :canon_model_id: PowerShot SD980 IS / Digital IXUS 200 IS / IXY Digital 930 IS
-:af_area_mode: Multi-point AF or AI AF
+:af_area_mode: Auto
 :num_af_points: 9
 :valid_af_points: 9
 :canon_image_width: 4000
@@ -179,13 +179,13 @@
 :luminance: 76.03647 80 87.12462
 :measurement_observer: CIE 1931
 :measurement_backing: 0 0 0
-:measurement_geometry: Unknown (0)
+:measurement_geometry: Unknown
 :measurement_flare: 0.999%
 :measurement_illuminant: D65
 :technology: Cathode Ray Tube Display
-:red_trc: (Binary data 2060 bytes)
-:green_trc: (Binary data 2060 bytes)
-:blue_trc: (Binary data 2060 bytes)
+:red_trc: (Binary data 2060 bytes, use -b option to extract)
+:green_trc: (Binary data 2060 bytes, use -b option to extract)
+:blue_trc: (Binary data 2060 bytes, use -b option to extract)
 :aperture: 2.8
 :drive_mode: Single-frame Shooting
 :image_size: 2248x4000
@@ -195,5 +195,8 @@
 :shutter_speed: !ruby/object:Rational
   denominator: 800
   numerator: 1
-:thumbnail_image: (Binary data 4627 bytes)
+:thumbnail_image: (Binary data 4627 bytes, use -b option to extract)
 :light_value: 11.9
+:file_type_extension: jpg
+:megapixels: 9.0
+:dof: inf (1.18 m - inf)

--- a/test/expected/faces.jpg.yaml
+++ b/test/expected/faces.jpg.yaml
@@ -48,7 +48,7 @@
 :metering_mode: Center-weighted average
 :focus_range: Not Known
 :canon_exposure_mode: Depth-of-field AE
-:lens_type: Unknown (-1)
+:lens_type: n/a
 :focal_units: 1/mm
 :flash_activity: 0
 :flash_bits: (none)
@@ -258,9 +258,9 @@
 :media_white_point: 0.95047 1 1.0891
 :chromatic_adaptation: 1.04788 0.02292 -0.0502 0.02957 0.99049 -0.01706 -0.00923 0.01508
   0.75165
-:red_trc: (Binary data 14 bytes)
-:green_trc: (Binary data 14 bytes)
-:blue_trc: (Binary data 14 bytes)
+:red_trc: (Binary data 14 bytes, use -b option to extract)
+:green_trc: (Binary data 14 bytes, use -b option to extract)
+:blue_trc: (Binary data 14 bytes, use -b option to extract)
 :profile_description: Camera RGB Profile
 :profile_copyright: Copyright 2003 Apple Computer Inc., all rights reserved.
 :profile_description_ml: Camera RGB Profile
@@ -299,8 +299,10 @@
 :shutter_speed: !ruby/object:Rational
   denominator: 4000
   numerator: 1
-:thumbnail_image: (Binary data 12170 bytes)
+:thumbnail_image: (Binary data 12170 bytes, use -b option to extract)
 :wb_rggb_levels: 1822 1015 1015 1709
 :blue_balance: 1.683744
 :light_value: 14.0
 :red_balance: 1.795074
+:megapixels: 8.2
+:file_type_extension: jpg

--- a/test/expected/iPhone 4S.jpg.yaml
+++ b/test/expected/iPhone 4S.jpg.yaml
@@ -69,5 +69,7 @@
 :shutter_speed: !ruby/object:Rational
   denominator: 6135
   numerator: 1
-:thumbnail_image: (Binary data 5987 bytes)
+:thumbnail_image: (Binary data 5987 bytes, use -b option to extract)
 :light_value: 15.8
+:megapixels: 8.0
+:file_type_extension: jpg


### PR DESCRIPTION
additional regex to catch `0000:00:00` and `0000:00:00 00:00:00` dates in the exif that is sometimes generated by scanner software and tests for it. I also updated tests to be compatible with v.9.98 of exiftool released on June 26th, 2015