### PR TITLE
Do not attempt to split raw numeric GPS coordinates

### DIFF
--- a/lib/exiftool/field_parser.rb
+++ b/lib/exiftool/field_parser.rb
@@ -46,7 +46,7 @@ class Exiftool
     end
 
     def as_lat_long
-      return raw_value if raw_value.is_a? Numeric
+      return raw_value if raw_value.is_a?(Numeric)
       value, direction = raw_value.split(' ')
       if value =~ /\A\d+\.?\d*\z/
         value.to_f * (['S', 'W'].include?(direction) ? -1 : 1)

--- a/lib/exiftool/field_parser.rb
+++ b/lib/exiftool/field_parser.rb
@@ -46,6 +46,7 @@ class Exiftool
     end
 
     def as_lat_long
+      return raw_value if raw_value.is_a? Numeric
       value, direction = raw_value.split(' ')
       if value =~ /\A\d+\.?\d*\z/
         value.to_f * (['S', 'W'].include?(direction) ? -1 : 1)

--- a/test/field_parser_test.rb
+++ b/test/field_parser_test.rb
@@ -85,4 +85,9 @@ describe Exiftool::FieldParser do
     p = Exiftool::FieldParser.new('GPSLongitude', '122.47566667 W')
     p.value.must_be_close_to(-122.47566667)
   end
+
+  it 'parses numerical only GPS coordinates' do
+    p = Exiftool::FieldParser.new('GPSLongitude', -122.475666666667)
+    p.value.must_be_close_to(-122.475666666667)
+  end
 end


### PR DESCRIPTION
Fixes #7
If `-n` option is used, GPS coordinates come as numeric values and there is no need to attempt to split cardinal directions from the value.

Also added a test for this scenario.